### PR TITLE
Stats Table Enhancement

### DIFF
--- a/client/src/components/StatsWarning.tsx
+++ b/client/src/components/StatsWarning.tsx
@@ -30,8 +30,9 @@ const StatsWarning = () => {
               </div>
               <div>
                 {warningCount}{' '}
-                {warningCount === 1 ? 'exchange is ' : 'exchanges are '}
-                not looking good.
+                {warningCount === 1
+                  ? 'exchange is showing a warning '
+                  : 'exchanges are showing warnings.'}
               </div>
             </div>
 

--- a/client/src/constants/data/positionsPage.tsx
+++ b/client/src/constants/data/positionsPage.tsx
@@ -16,7 +16,6 @@ import WalletRowActionButtons from '../../components/WalletRowActionButtons';
 // import { Link } from 'react-router-dom';
 // import { FiEdit2 } from 'react-icons/fi';
 
-
 export const positionGroupsTableColumn: TableColumn<PositionsGroup>[] = [
   {
     label: 'Date',
@@ -186,7 +185,6 @@ export const subPositionsTableColumn: TableColumn<Position>[] = [
     label: '%TP',
     value: 'percent_take_profit',
   },
-
 ];
 
 export const exchangesBalanceTableColumn: TableColumn<ExchangeBalance>[] = [
@@ -336,12 +334,12 @@ export const investorActionTableColumn: TableColumn<InvestorAction>[] = [
 ];
 
 export const statusExchangesColumns: TableColumn<StatExchange>[] = [
-  { label: "Exchange", value: "exchange" },
-  { label: "History Count", value: "history_count" },
-  { label: "Market Count", value: "markets_count" },
+  { label: 'Exchange', value: 'exchange' },
+  { label: 'History Count', value: 'history_count' },
+  { label: 'Market Count', value: 'markets_count' },
   {
-    label: "Failure Tasks Count",
-    value: "failed_tasks_count",
+    label: 'Failure Tasks Count',
+    value: 'failed_tasks_count',
     render: (item) => {
       const failed_tasks_count =
         item.realtime_data_failure_rate.failed_tasks_count;
@@ -349,8 +347,8 @@ export const statusExchangesColumns: TableColumn<StatExchange>[] = [
     },
   },
   {
-    label: "Total Tasks Count",
-    value: "total_tasks_count",
+    label: 'Total Tasks Count',
+    value: 'total_tasks_count',
     render: (item) => {
       const total_tasks_count =
         item.realtime_data_failure_rate.total_tasks_count;
@@ -358,8 +356,8 @@ export const statusExchangesColumns: TableColumn<StatExchange>[] = [
     },
   },
   {
-    label: "Failure Rate Percentage (%)",
-    value: "failure_rate_percent",
+    label: 'Failure Rate Percentage (%)',
+    value: 'failure_rate_percent',
     render: (item) => {
       const failure_rate_percent =
         item.realtime_data_failure_rate.failure_rate_percent;
@@ -367,16 +365,95 @@ export const statusExchangesColumns: TableColumn<StatExchange>[] = [
     },
   },
   {
-    label: "Latest Update",
-    value: "latest_update",
+    label: 'Latest Update',
+    value: 'latest_update',
     render: (item) => {
       const timeUpdated = moment(item.latest_update).fromNow();
       return timeUpdated[0].toUpperCase() + timeUpdated.slice(1);
     },
   },
   {
-    label: "Warning",
-    value: "warning",
+    label: 'Latest RT',
+    value: 'latest_rt',
+    render: (item) => {
+      const timeUpdated = moment(item.latest_update_realtime).fromNow();
+      return timeUpdated[0].toUpperCase() + timeUpdated.slice(1);
+    },
+  },
+  {
+    label: 'M&H',
+    value: 'm&h',
+    tableHeadCellClassName: 'min-w-[10em]',
+    render: (item) => {
+      return (
+        <div>
+          <p>
+            {item.markets_and_history_failure_rate.failure_rate_percent.toFixed(
+              2
+            )}
+            %
+          </p>
+          <p className="text-xs opacity-60">
+            {item.markets_and_history_failure_rate.failed_tasks_count}/
+            {item.markets_and_history_failure_rate.total_tasks_count}
+          </p>
+        </div>
+      );
+    },
+  },
+  {
+    label: 'RT Fail Rate',
+    value: 'rt_fail_rate',
+    tableHeadCellClassName: 'min-w-[10em]',
+    render: (item) => {
+      return (
+        <div>
+          <p>
+            {item.realtime_data_failure_rate.failure_rate_percent.toFixed(2)}%
+          </p>
+          <p className="text-xs opacity-60">
+            {item.realtime_data_failure_rate.failed_tasks_count}/
+            {item.realtime_data_failure_rate.total_tasks_count}
+          </p>
+        </div>
+      );
+    },
+  },
+  {
+    label: 'RT Status',
+    value: 'rt_status',
+    render: (item) => {
+      let bgColor = '';
+      switch (item.realtime_status.toLocaleLowerCase()) {
+        case 'ok':
+          bgColor = '#16A34A';
+          break;
+        case 'warning':
+          bgColor = '#CA8A04';
+          break;
+        case 'error':
+          bgColor = '#DC2626';
+          break;
+        default:
+          bgColor = '#DDDDDD';
+      }
+      return (
+        <div
+          className={`text-white/90 px-4 py-2 rounded-full inline opacity-80 ${
+            item.realtime_status.toLowerCase() !== 'ok'
+              ? 'capitalize'
+              : 'uppercase'
+          }`}
+          style={{ backgroundColor: bgColor }}
+        >
+          {item.realtime_status.toLowerCase()}
+        </div>
+      );
+    },
+  },
+  {
+    label: 'Warning',
+    value: 'warning',
     render: (item) => {
       return item.warning ? (
         <div className="text-white/90 px-4 py-2 rounded-full bg-yellow-600 inline opacity-80">

--- a/client/src/constants/data/positionsPage.tsx
+++ b/client/src/constants/data/positionsPage.tsx
@@ -4,17 +4,14 @@ import {
   InvestorAction,
   Position,
   PositionsGroup,
-  StatExchange,
   TableColumn,
   Wallet,
 } from '../../types';
 import { shortenString } from '../../utils/stringTool';
 import InvestorRowActions from '../../components/InvestorRowActions';
 import { get24HourDateTime } from '../../utils/dateUtils';
-import moment from 'moment';
+
 import WalletRowActionButtons from '../../components/WalletRowActionButtons';
-// import { Link } from 'react-router-dom';
-// import { FiEdit2 } from 'react-icons/fi';
 
 export const positionGroupsTableColumn: TableColumn<PositionsGroup>[] = [
   {
@@ -330,140 +327,5 @@ export const investorActionTableColumn: TableColumn<InvestorAction>[] = [
     label: 'Amount',
     value: 'amount',
     render: (item: InvestorAction) => item.amount.toFixed(4),
-  },
-];
-
-export const statusExchangesColumns: TableColumn<StatExchange>[] = [
-  { label: 'Exchange', value: 'exchange' },
-  { label: 'History Count', value: 'history_count' },
-  { label: 'Market Count', value: 'markets_count' },
-  {
-    label: 'Failure Tasks Count',
-    value: 'failed_tasks_count',
-    render: (item) => {
-      const failed_tasks_count =
-        item.realtime_data_failure_rate.failed_tasks_count;
-      return failed_tasks_count;
-    },
-  },
-  {
-    label: 'Total Tasks Count',
-    value: 'total_tasks_count',
-    render: (item) => {
-      const total_tasks_count =
-        item.realtime_data_failure_rate.total_tasks_count;
-      return total_tasks_count;
-    },
-  },
-  {
-    label: 'Failure Rate Percentage (%)',
-    value: 'failure_rate_percent',
-    render: (item) => {
-      const failure_rate_percent =
-        item.realtime_data_failure_rate.failure_rate_percent;
-      return failure_rate_percent.toFixed(3);
-    },
-  },
-  {
-    label: 'Latest Update',
-    value: 'latest_update',
-    render: (item) => {
-      const timeUpdated = moment(item.latest_update).fromNow();
-      return timeUpdated[0].toUpperCase() + timeUpdated.slice(1);
-    },
-  },
-  {
-    label: 'Latest RT',
-    value: 'latest_rt',
-    render: (item) => {
-      const timeUpdated = moment(item.latest_update_realtime).fromNow();
-      return timeUpdated[0].toUpperCase() + timeUpdated.slice(1);
-    },
-  },
-  {
-    label: 'M&H',
-    value: 'm&h',
-    tableHeadCellClassName: 'min-w-[10em]',
-    render: (item) => {
-      return (
-        <div>
-          <p>
-            {item.markets_and_history_failure_rate.failure_rate_percent.toFixed(
-              2
-            )}
-            %
-          </p>
-          <p className="text-xs opacity-60">
-            {item.markets_and_history_failure_rate.failed_tasks_count}/
-            {item.markets_and_history_failure_rate.total_tasks_count}
-          </p>
-        </div>
-      );
-    },
-  },
-  {
-    label: 'RT Fail Rate',
-    value: 'rt_fail_rate',
-    tableHeadCellClassName: 'min-w-[10em]',
-    render: (item) => {
-      return (
-        <div>
-          <p>
-            {item.realtime_data_failure_rate.failure_rate_percent.toFixed(2)}%
-          </p>
-          <p className="text-xs opacity-60">
-            {item.realtime_data_failure_rate.failed_tasks_count}/
-            {item.realtime_data_failure_rate.total_tasks_count}
-          </p>
-        </div>
-      );
-    },
-  },
-  {
-    label: 'RT Status',
-    value: 'rt_status',
-    render: (item) => {
-      let bgColor = '';
-      switch (item.realtime_status.toLocaleLowerCase()) {
-        case 'ok':
-          bgColor = '#16A34A';
-          break;
-        case 'warning':
-          bgColor = '#CA8A04';
-          break;
-        case 'error':
-          bgColor = '#DC2626';
-          break;
-        default:
-          bgColor = '#DDDDDD';
-      }
-      return (
-        <div
-          className={`text-white/90 px-4 py-2 rounded-full inline opacity-80 ${
-            item.realtime_status.toLowerCase() !== 'ok'
-              ? 'capitalize'
-              : 'uppercase'
-          }`}
-          style={{ backgroundColor: bgColor }}
-        >
-          {item.realtime_status.toLowerCase()}
-        </div>
-      );
-    },
-  },
-  {
-    label: 'Warning',
-    value: 'warning',
-    render: (item) => {
-      return item.warning ? (
-        <div className="text-white/90 px-4 py-2 rounded-full bg-yellow-600 inline opacity-80">
-          Warning
-        </div>
-      ) : (
-        <div className="text-white/90 px-4 py-2 rounded-full bg-green-600 inline opacity-80">
-          All good
-        </div>
-      );
-    },
   },
 ];

--- a/client/src/constants/data/system.tsx
+++ b/client/src/constants/data/system.tsx
@@ -1,0 +1,137 @@
+import moment from 'moment';
+import { StatExchange, TableColumn } from '../../types';
+
+export const statusExchangesColumns: TableColumn<StatExchange>[] = [
+  { label: 'Exchange', value: 'exchange' },
+  { label: 'History Count', value: 'history_count' },
+  { label: 'Market Count', value: 'markets_count' },
+  {
+    label: 'Failure Tasks Count',
+    value: 'failed_tasks_count',
+    render: (item) => {
+      const failed_tasks_count =
+        item.realtime_data_failure_rate.failed_tasks_count;
+      return failed_tasks_count;
+    },
+  },
+  {
+    label: 'Total Tasks Count',
+    value: 'total_tasks_count',
+    render: (item) => {
+      const total_tasks_count =
+        item.realtime_data_failure_rate.total_tasks_count;
+      return total_tasks_count;
+    },
+  },
+  {
+    label: 'Failure Rate Percentage (%)',
+    value: 'failure_rate_percent',
+    render: (item) => {
+      const failure_rate_percent =
+        item.realtime_data_failure_rate.failure_rate_percent;
+      return failure_rate_percent.toFixed(3);
+    },
+  },
+  {
+    label: 'Latest Update',
+    value: 'latest_update',
+    render: (item) => {
+      const timeUpdated = moment(item.latest_update).fromNow();
+      return timeUpdated[0].toUpperCase() + timeUpdated.slice(1);
+    },
+  },
+  {
+    label: 'Latest RT',
+    value: 'latest_rt',
+    render: (item) => {
+      const timeUpdated = moment(item.latest_update_realtime).fromNow();
+      return timeUpdated[0].toUpperCase() + timeUpdated.slice(1);
+    },
+  },
+  {
+    label: 'M&H',
+    value: 'm&h',
+    tableHeadCellClassName: 'min-w-[10em]',
+    render: (item) => {
+      return (
+        <div>
+          <p>
+            {item.markets_and_history_failure_rate.failure_rate_percent.toFixed(
+              2
+            )}
+            %
+          </p>
+          <p className="text-xs opacity-60">
+            {item.markets_and_history_failure_rate.failed_tasks_count}/
+            {item.markets_and_history_failure_rate.total_tasks_count}
+          </p>
+        </div>
+      );
+    },
+  },
+  {
+    label: 'RT Fail Rate',
+    value: 'rt_fail_rate',
+    tableHeadCellClassName: 'min-w-[10em]',
+    render: (item) => {
+      return (
+        <div>
+          <p>
+            {item.realtime_data_failure_rate.failure_rate_percent.toFixed(2)}%
+          </p>
+          <p className="text-xs opacity-60">
+            {item.realtime_data_failure_rate.failed_tasks_count}/
+            {item.realtime_data_failure_rate.total_tasks_count}
+          </p>
+        </div>
+      );
+    },
+  },
+  {
+    label: 'RT Status',
+    value: 'rt_status',
+    render: (item) => {
+      let bgColor = '';
+      switch (item.realtime_status.toLocaleLowerCase()) {
+        case 'ok':
+          bgColor = '#16A34A';
+          break;
+        case 'warning':
+          bgColor = '#CA8A04';
+          break;
+        case 'error':
+          bgColor = '#DC2626';
+          break;
+        default:
+          bgColor = '#DDDDDD';
+      }
+      return (
+        <div
+          className={`text-white/90 px-4 py-2 rounded-full inline opacity-80 ${
+            item.realtime_status.toLowerCase() !== 'ok'
+              ? 'capitalize'
+              : 'uppercase'
+          }`}
+          style={{ backgroundColor: bgColor }}
+        >
+          {item.realtime_status.toLowerCase()}
+        </div>
+      );
+    },
+  },
+  {
+    label: 'Warning',
+    value: 'warning',
+    render: (item) => {
+      return item.warning ? (
+        <div className="text-white/90 px-4 py-2 rounded-full bg-yellow-600 inline opacity-80">
+          Warning
+        </div>
+      ) : (
+        <div className="text-white/90 px-4 py-2 rounded-full bg-green-600 inline opacity-80">
+          All good
+        </div>
+      );
+    },
+  },
+];

--- a/client/src/pages/System.tsx
+++ b/client/src/pages/System.tsx
@@ -1,6 +1,6 @@
 import AppTable from '../components/AppTable';
 import PaginationControls from '../components/PaginationControls';
-import { statusExchangesColumns } from '../constants/data/positionsPage';
+import { statusExchangesColumns } from '../constants/data/system';
 import { useAppSelector } from '../hooks';
 import { StatExchange } from '../types';
 

--- a/client/src/pages/System.tsx
+++ b/client/src/pages/System.tsx
@@ -17,7 +17,7 @@ const System = () => {
           <h3 className="text-white/90 font-semibold">Stats</h3>
         </div>
 
-        <div className="overflow-x-auto max-h-[80vh]">
+        <div className="overflow-x-auto">
           {stats.loading ? (
             <div className="text-sm text-white/90 w-full h-full flex justify-center items-center">
               Loading Stats...


### PR DESCRIPTION
- Added latest_update_realtime to display the latest time a realtime task ran successfully. Includes "ago" parser.
- Added markets_and_history_failure_rate to show fail rate percent and fail/total numbers in the same cell.
- Added realtime_data_failure_rate with similar formatting.
- Added realtime_status chip displaying OK, WARNING, or ERROR.

![Screenshot 2024-07-29 163519](https://github.com/user-attachments/assets/f73a8982-0d04-44ad-935a-4b5b33255c8f)
